### PR TITLE
Seederファイルを公開用に変更

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -7,13 +7,15 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
       $this->call([
+/* 公開時にはコメントアウト
         Lab_evaluationTableSeeder::class,
         LaboratoriesTableSeeder::class,
+        DepartmentTableSeeder::class,
+        UsersTableSeeder::class,
+*/
         Univ_dataTableSeeder::class,
         Prefecture_imagesTableSeeder::class,
         Faculty_logosTableSeeder::class,
-        DepartmentTableSeeder::class,
-        UsersTableSeeder::class,
      ]);
     }
 }


### PR DESCRIPTION
テスト時は、以下ファイルのコメントアウトを外す

minlabo/database/seeds/DatabaseSeeder.php
`<?php

use Illuminate\Database\Seeder;

class DatabaseSeeder extends Seeder
{
    public function run()
    {
      $this->call([
/* 公開時にはコメントアウト
        Lab_evaluationTableSeeder::class,
        LaboratoriesTableSeeder::class,
        DepartmentTableSeeder::class,
        UsersTableSeeder::class,
*/
        Univ_dataTableSeeder::class,
        Prefecture_imagesTableSeeder::class,
        Faculty_logosTableSeeder::class,
     ]);
    }
}`